### PR TITLE
[BSMTS-419] Odoo error message on Print QR Code

### DIFF
--- a/l10n_ch_qr_bill/report/swissqr_report.xml
+++ b/l10n_ch_qr_bill/report/swissqr_report.xml
@@ -30,7 +30,7 @@
                 <!--<script>document.body.className += " l10n_ch_qr";</script>-->
                 <div class="page l10n_ch_qr">
 
-                    <t t-set="formated_amount" t-value="'{:,.2f}'.format(o.residual)"/>
+                    <t t-set="formated_amount" t-value="'{:,.2f}'.format(o.residual).replace(',','\'')"/>
 
                     <div class="swissqr_title">
                         <h1>QR-bill for invoice <t t-esc="o.number"/></h1>

--- a/l10n_ch_qr_bill/report/swissqr_report.xml
+++ b/l10n_ch_qr_bill/report/swissqr_report.xml
@@ -30,7 +30,7 @@
                 <!--<script>document.body.className += " l10n_ch_qr";</script>-->
                 <div class="page l10n_ch_qr">
 
-                    <t t-set="formated_amount" t-value="'{:,.2f}'.format(o.residual).replace(',','\xa0')"/>
+                    <t t-set="formated_amount" t-value="'{:,.2f}'.format(o.residual)"/>
 
                     <div class="swissqr_title">
                         <h1>QR-bill for invoice <t t-esc="o.number"/></h1>

--- a/l10n_ch_qr_bill/report/swissqr_report.xml
+++ b/l10n_ch_qr_bill/report/swissqr_report.xml
@@ -29,7 +29,7 @@
                 <!-- add class to body tag -->
                 <!--<script>document.body.className += " l10n_ch_qr";</script>-->
                 <div class="page l10n_ch_qr">
-                    <t t-set="formated_amount" t-value="'{:,.2f}'.format(o.residual).replace(',','')"/>
+                    <t t-set="formated_amount" t-value="'{:,.2f}'.format(o.residual).replace(',',' ')"/>
 
                     <div class="swissqr_title">
                         <h1>QR-bill for invoice <t t-esc="o.number"/></h1>

--- a/l10n_ch_qr_bill/report/swissqr_report.xml
+++ b/l10n_ch_qr_bill/report/swissqr_report.xml
@@ -29,7 +29,7 @@
                 <!-- add class to body tag -->
                 <!--<script>document.body.className += " l10n_ch_qr";</script>-->
                 <div class="page l10n_ch_qr">
-
+                    <!--FIXME for thousand separators an non-breakable space would be better but as it could break encoding we prefer to use a single quote -->
                     <t t-set="formated_amount" t-value="'{:,.2f}'.format(o.residual).replace(',','\'')"/>
 
                     <div class="swissqr_title">

--- a/l10n_ch_qr_bill/report/swissqr_report.xml
+++ b/l10n_ch_qr_bill/report/swissqr_report.xml
@@ -29,8 +29,7 @@
                 <!-- add class to body tag -->
                 <!--<script>document.body.className += " l10n_ch_qr";</script>-->
                 <div class="page l10n_ch_qr">
-                    <!--FIXME for thousand separators an non-breakable space would be better but as it could break encoding we prefer to use a single quote -->
-                    <t t-set="formated_amount" t-value="'{:,.2f}'.format(o.residual).replace(',','\'')"/>
+                    <t t-set="formated_amount" t-value="'{:,.2f}'.format(o.residual).replace(',','')"/>
 
                     <div class="swissqr_title">
                         <h1>QR-bill for invoice <t t-esc="o.number"/></h1>

--- a/l10n_ch_qr_bill/static/src/css/report_swissqr.css
+++ b/l10n_ch_qr_bill/static/src/css/report_swissqr.css
@@ -93,6 +93,7 @@
 
 .page.l10n_ch_qr .swissqr_text .content {
 	font-size: 10pt;
+	white-space: nowrap;
 }
 
 .page.l10n_ch_qr .main_title {


### PR DESCRIPTION
Fixing:
```Traceback (most recent call last):
  File "/odoo/src/addons/report/controllers/main.py", line 96, in report_download
    response = self.report_routes(reportname, docids=docids, converter='pdf')
  File "/odoo/src/odoo/http.py", line 507, in response_wrap
    response = f(*args, **kw)
  File "/odoo/external-src/reporting-engine/report_py3o/controllers/main.py", line 25, in report_routes
    **data)
  File "/odoo/src/odoo/http.py", line 507, in response_wrap
    response = f(*args, **kw)
  File "/odoo/src/addons/report/controllers/main.py", line 45, in report_routes
    pdf = report_obj.with_context(context).get_pdf(docids, reportname, data=data)
  File "/odoo/local-src/mtsmte_reports/models/report.py", line 24, in get_pdf
    return super(Report, self).get_pdf(docids, report_name, html, data)
  File "/odoo/external-src/l10n-switzerland/l10n_ch_payment_slip/report/report.py", line 151, in get_pdf
    data=data)
  File "/odoo/src/addons/report/models/report.py", line 181, in get_pdf
    html = self.with_context(context).get_html(docids, report_name, data=data)
  File "/odoo/src/addons/report/models/report.py", line 147, in get_html
    return self.render(report.report_name, docargs)
  File "/odoo/src/addons/report/models/report.py", line 123, in render
    return view_obj.render_template(template, values)
  File "/odoo/src/odoo/addons/base/ir/ir_ui_view.py", line 1052, in render_template
    return self.browse(self.get_view_id(template)).render(values, engine)
  File "/odoo/src/addons/website/models/ir_ui_view.py", line 115, in render
    return super(View, self).render(values, engine=engine)
  File "/odoo/src/addons/web_editor/models/ir_ui_view.py", line 26, in render
    return super(IrUiView, self).render(values=values, engine=engine)
  File "/odoo/src/odoo/addons/base/ir/ir_ui_view.py", line 1072, in render
    return self.env[engine].render(self.id, qcontext)
  File "/odoo/src/odoo/addons/base/ir/ir_qweb/ir_qweb.py", line 53, in render
    return super(IrQWeb, self).render(id_or_xml_id, values=values, **context)
  File "/odoo/src/odoo/addons/base/ir/ir_qweb/qweb.py", line 251, in render
    self.compile(template, options)(self, body.append, values or {})
  File "/odoo/src/odoo/addons/base/ir/ir_qweb/qweb.py", line 320, in _compiled_fn
    raise e
QWebException: 'utf8' codec can't decode byte 0xa0 in position 1: invalid start byte
Traceback (most recent call last):
  File "/odoo/src/odoo/addons/base/ir/ir_qweb/qweb.py", line 318, in _compiled_fn
    return compiled(self, append, values, options, log)
  File "<template>", line 1, in template_l10n_ch_qr_bill_l10n_ch_swissqr_template_130
  File "<template>", line 3, in body_call_content_129
  File "/odoo/src/odoo/addons/base/ir/ir_qweb/qweb.py", line 157, in unicodifier
    return val.decode('utf-8')
  File "/usr/lib/python2.7/encodings/utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xa0 in position 1: invalid start byte

Error to render compiling AST
UnicodeDecodeError: 'utf8' codec can't decode byte 0xa0 in position 1: invalid start byte
Template: l10n_ch_qr_bill.l10n_ch_swissqr_template
Path: /templates/t/t/div/div[2]/div[1]/div[3]/div/div[2]/span[2]
Node: <span class="content" t-esc="formated_amount"/>