### PR TITLE
[IMP] Add QR-IBAN search to get proper bank account during import

### DIFF
--- a/l10n_ch_qr_bill_scan/__init__.py
+++ b/l10n_ch_qr_bill_scan/__init__.py
@@ -1,2 +1,3 @@
+from . import models
 from . import wizard
 from . import tools

--- a/l10n_ch_qr_bill_scan/__manifest__.py
+++ b/l10n_ch_qr_bill_scan/__manifest__.py
@@ -10,7 +10,11 @@
     "category": "Localization",
     "website": "https://github.com/OCA/l10n-switzerland",
     "license": "AGPL-3",
-    "depends": ["l10n_ch", "account_invoice_import"],
+    "depends": [
+        "l10n_ch",
+        "account_invoice_import",
+        "l10n_ch_qr_bill",
+    ],
     "data": ["wizard/account_invoice_import_view.xml"],
     "auto_install": False,
     "installable": True,

--- a/l10n_ch_qr_bill_scan/models/__init__.py
+++ b/l10n_ch_qr_bill_scan/models/__init__.py
@@ -1,0 +1,1 @@
+from . import business_document_import

--- a/l10n_ch_qr_bill_scan/models/business_document_import.py
+++ b/l10n_ch_qr_bill_scan/models/business_document_import.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
-# Copyright 2020 Camptocamp
+# Copyright 2020-2021 Camptocamp
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import api, models
+
+from odoo import _, api, models
+
+from odoo.addons.base_iban.models.res_partner_bank import (
+    normalize_iban, pretty_iban
+)
 
 
 class BusinessDocumentImport(models.AbstractModel):
-    _name = "business.document.import"
-    _description = "Common methods to import business documents"
+    _inherit = "business.document.import"
 
     @api.model
     def _hook_match_partner(
@@ -14,3 +18,46 @@ class BusinessDocumentImport(models.AbstractModel):
     ):
         # TODO search by iban
         return False
+
+    @api.model
+    def _match_partner_bank(
+            self, partner, iban, bic, chatter_msg, create_if_not_found=False):
+        '''Bank accounts with provided QR-IBAN
+           should be found before Account/IBAN Number
+        '''
+        assert iban, 'iban is a required arg'
+        assert partner, 'partner is a required arg'
+        rpbo = self.env['res.partner.bank']
+        partner = partner.commercial_partner_id
+        iban = iban.replace(' ', '').upper()
+        try:
+            rpbo._validate_qr_iban(iban)
+        except:
+            chatter_msg.append(_(
+                "IBAN <b>%s</b> is not valid, so it has been ignored.") % iban)
+            return False
+        company_id = self._context.get('force_company') or (
+            self.env.user.company_id.id
+        )
+        qr_iban = pretty_iban(normalize_iban(iban))
+        qr_iban_obj = rpbo.search([
+            '|', ('company_id', '=', False),
+            ('company_id', '=', company_id),
+            ('l10n_ch_qr_iban', '=', qr_iban),
+            ('partner_id', '=', partner.id),
+            ])
+        if qr_iban_obj:
+            if len(qr_iban_obj) == 1:
+                return qr_iban_obj
+            else:
+                chatter_msg.append(_(
+                    "The analysis of the business document returned "
+                    "<b>QR-IBAN %s</b> as bank account, but there are several "
+                    "bank accounts in Odoo linked to partner <b>%s</b>."
+                    "Please select propper bank account on Invoice.")
+                    % (qr_iban, partner.display_name))
+        else:
+            bankaccount = super(BusinessDocumentImport, self)._match_partner_bank(
+                partner, iban, bic, chatter_msg, create_if_not_found
+            )
+            return bankaccount


### PR DESCRIPTION
Suppose we have l10n_ch_qr_iban field (QR-IBAN) on res.partner.bank model.
Then during Importing Vendor bill with passing Invoice scan data we are searching only on existing Account/IBAN Numbers, which are unique. This is correct.
But, we also can have QR-IBAN's with the same IBAN and they are not handled at the moment, so we get on Invoice not correct Bank account.
This improvement is aimed to do:
- first search on existing QR-IBAN's
- if found use that Bank account to prepare Invoice data
- if found several (as QR-IBAN isn't unique field) post message in chatter informing user about that fact
- if not found super function will be called to proceed on existing implementation